### PR TITLE
Make tests cleanup after themselves (no more transaction leftovers)

### DIFF
--- a/ING Research/src/accounts/Transaction.java
+++ b/ING Research/src/accounts/Transaction.java
@@ -24,6 +24,8 @@ public class Transaction implements DBObject{
 	private float amount;
 	private String description;
 	private int id;
+	public static final String CLASSNAME = "accounts.Transaction";
+	public static final String PRIMARYKEYNAME = "id";
 	
 	public Transaction() {
 		
@@ -100,7 +102,7 @@ public class Transaction implements DBObject{
 	@Override
 	@Transient
 	public String getPrimaryKeyName() {
-		return "id";
+		return PRIMARYKEYNAME;
 	}
 
 	@Override
@@ -112,7 +114,7 @@ public class Transaction implements DBObject{
 	@Override
 	@Transient
 	public String getClassName() {
-		return "accounts.Transaction";
+		return CLASSNAME;
 	}
 
 	@Override

--- a/ING Research/src/testing/AccountTest.java
+++ b/ING Research/src/testing/AccountTest.java
@@ -2,14 +2,18 @@ package testing;
 
 import static org.junit.Assert.*;
 
+import java.util.ArrayList;
 import java.util.Set;
 
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 
 import accounts.BankAccount;
 import accounts.CustomerAccount;
+import accounts.Transaction;
+import database.DataManager;
 import exceptions.IllegalAmountException;
 import exceptions.IllegalTransferException;
 
@@ -183,5 +187,15 @@ public class AccountTest {
 		assertTrue(bankAccount2.getBalance() == 100);
 		assertTrue(bankAccount.getBalance() == 0);
 		bankAccount2.deleteFromDB();
+	}
+	
+	@AfterClass
+	public static void cleanup() {
+		@SuppressWarnings("unchecked")
+		ArrayList<Transaction> ts = (ArrayList<Transaction>) DataManager.getObjectsFromDB(Transaction.CLASSNAME);
+		
+		for (Transaction t : ts) {
+			t.deleteFromDB();
+		}
 	}
 }

--- a/ING Research/src/testing/DebitCardTest.java
+++ b/ING Research/src/testing/DebitCardTest.java
@@ -1,10 +1,14 @@
 package testing;
 
+import java.util.ArrayList;
+
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 
 import accounts.BankAccount;
 import accounts.DebitCard;
+import accounts.Transaction;
 import database.DataManager;
 
 public class DebitCardTest {
@@ -48,5 +52,15 @@ public class DebitCardTest {
 		assert(bAcc.getBalance() == 9000 && bAcc2.getBalance() == 1000);
 		bAcc.deleteFromDB();
 		bAcc2.deleteFromDB();
+	}
+	
+	@AfterClass
+	public static void cleanup() {
+		@SuppressWarnings("unchecked")
+		ArrayList<Transaction> ts = (ArrayList<Transaction>) DataManager.getObjectsFromDB(Transaction.CLASSNAME);
+		
+		for (Transaction t : ts) {
+			t.deleteFromDB();
+		}
 	}
 }


### PR DESCRIPTION
JUnit tests no longer leave any transactions in the database after
finishing.

Also added CLASSNAME and PRIMARYKEYNAME to Transaction, as it was
necessary for the aforementioned cleanup to work.